### PR TITLE
XMLAttributeProcessor: Remove functions which do nothing

### DIFF
--- a/ugh/src/converter/processing/XMLAttributeProcessor.java
+++ b/ugh/src/converter/processing/XMLAttributeProcessor.java
@@ -124,14 +124,4 @@ public class XMLAttributeProcessor {
 
 	}
 
-	public void saveTo(String fileName) {
-		if (fileName == null)
-			fileName = myDocPath + ".bak";
-
-	}
-
-	public void saveChanges() {
-
-	}
-
 }


### PR DESCRIPTION
Function saveTo was reported by FindBugs.
Both function names pretend some functionality which is not implemented.

Signed-off-by: Stefan Weil <sw@weilnetz.de>