### PR TITLE
Replace multiple occurrences of ‘uncounted’

### DIFF
--- a/ugh/src/ugh/fileformats/mets/MetsModsImportExport.java
+++ b/ugh/src/ugh/fileformats/mets/MetsModsImportExport.java
@@ -492,11 +492,8 @@ public class MetsModsImportExport extends ugh.fileformats.mets.MetsMods {
                 // Write logical page number into div, if current metadata value
                 // is not METADATA_PAGE_UNCOUNTED_VALUE.
                 else if (currentMd.getType().getName().equals(METADATA_LOGICAL_PAGE_NUMBER)) {
-                    if (!currentMd.getValue().equals(METADATA_PAGE_UNCOUNTED_VALUE)) {
-                        divElement.setAttribute(METS_ORDERLABEL_STRING, currentMd.getValue());
-                    } else {
-                        divElement.setAttribute(METS_ORDERLABEL_STRING, " - ");
-                    }
+                    divElement.setAttribute(METS_ORDERLABEL_STRING, currentMd.getValue()
+                            .replace(METADATA_PAGE_UNCOUNTED_VALUE, " - "));
 
                     notMappedMetadataAndPersons.remove(currentMd);
                 } else {


### PR DESCRIPTION
Current UGH code cannot handle several occurrences of ‘uncounted’ pagination. In case of a single `uncounted`, the visible page label ` - ` is wirtten into the METS file, but in any combinations that may occur with double page pagination, such as `uncounted;uncounted` or `uncounted;1` the string is not modified. This patch changes the output so that the last examples will instead be output as ` - ; - ` or ` - ;1`.