### PR TITLE
Fixes a NullPointerException

### DIFF
--- a/ugh/src/ugh/dl/DocStruct.java
+++ b/ugh/src/ugh/dl/DocStruct.java
@@ -3967,6 +3967,9 @@ public class DocStruct implements Serializable {
 	 *             if the child indicated cannot be reached
 	 */
 	public DocStruct getChild(String reference) {
+		if(children == null) {
+			throw new IndexOutOfBoundsException(reference);
+		}
 		int fieldSeparator;
 		if ((fieldSeparator = reference.indexOf(',')) > -1) {
 			int index = Integer.parseInt(reference.substring(0, fieldSeparator));

--- a/ugh/src/ugh/fileformats/mets/MetsMods.java
+++ b/ugh/src/ugh/fileformats/mets/MetsMods.java
@@ -1339,9 +1339,14 @@ public class MetsMods implements ugh.dl.Fileformat {
 
 					// when done, write the origen document back
 					this.getDigitalDocument().setLogicalDocStruct(origen);
-				} catch (UGHException caught) {
-					throw caught instanceof ReadException ? (ReadException) caught : new ReadException(
-							caught.getMessage(), caught);
+				} catch (ReadException canBeThrownDirectly) {
+					throw canBeThrownDirectly ;
+				} catch (UGHException|IndexOutOfBoundsException wrappedException) {
+					String reason = wrappedException.getClass().getSimpleName();
+					if (wrappedException.getMessage() != null) {
+						reason += ": " + wrappedException.getMessage();
+					}
+					throw new ReadException(reason, wrappedException);
 				}
 			}
 


### PR DESCRIPTION
`getChild()` threw `NullPointerException` when “children” was `null`.