### PR TITLE
Export fields of meta-data groups to MODS XML attributes

### DIFF
--- a/ugh/src/ugh/fileformats/mets/MetsMods.java
+++ b/ugh/src/ugh/fileformats/mets/MetsMods.java
@@ -3534,6 +3534,12 @@ public class MetsMods implements ugh.dl.Fileformat {
                     currentPath += "/" + element;
                 }
             }
+            // Check, if the element name starts with a "@", if so, an attribute
+            // needs to be created.
+            else if (element.startsWith("@")) {
+                // Get out of loop.
+                break;
+            }
             // We are requesting an element.
             else {
                 requestingElement = true;
@@ -4223,6 +4229,11 @@ public class MetsMods implements ugh.dl.Fileformat {
             throw new PreferencesException(message);
         }
 
+        // Add value to attribute.
+        if(createdNode instanceof Attr){
+            ((Attr) createdNode).setValue(theMetadata.getValue());
+            return;
+        }
         // Add value to node.
         Node valueNode = theDocument.createTextNode(theMetadata.getValue());
         createdNode.appendChild(valueNode);


### PR DESCRIPTION
Part of https://github.com/kitodo/kitodo-production/issues/619

Example usage:
``` xml
<Preferences>

<!-- ... -->

<MetadataType>
    <Name>ctrIdentifierURI</Name>
    <language name="en">Identifier (GND)</language>
</MetadataType>

<!-- ... -->

<Group>
  <Name>Contributor</Name>
  <language name="en">Contributor</language>
  <!-- ... -->
  <metadata>ctrIdentifierURI</metadata>
  <!-- ... -->
</Group>

<Formats>
  <METS>
    <!-- ... -->
    <Group>
      <InternalName>Contributor</InternalName>
      <WriteXPath>./mods:mods/#mods:name[@type='personal']</WriteXPath>
      <!-- ... -->
      <Metadata>
        <InternalName>ctrIdentifierURI</InternalName>
        <WriteXPath>./@valueURI</WriteXPath>            <!-- *** HERE *** -->
      </Metadata>
      <!-- ... -->
```