### PR TITLE
Cause an empty list to be handled as ‘no children’ case as well

### DIFF
--- a/ugh/src/ugh/dl/DocStruct.java
+++ b/ugh/src/ugh/dl/DocStruct.java
@@ -813,7 +813,7 @@ public class DocStruct implements Serializable {
 		if (getMetadataByType(MetsModsImportExport.CREATE_MPTR_ELEMENT_TYPE).size() > 0) {
 			return true;
 		}
-		if (children == null) {
+		if (children == null || children.isEmpty()) {
 			return false;
 		}
 		for (DocStruct child : children) {


### PR DESCRIPTION
Bug fix for bug #58

Usually, if there are no children, `children` is null. However, if reading from XStream, there may also be an empty list object stored in the XStream file, which has the same semantics.