### PR TITLE
Add OracleJDK and OpenJDK to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,8 @@
 
 language: java
 
+jdk:
+  - oraclejdk7
+  - openjdk7
+
 script: cd ugh && ant all


### PR DESCRIPTION
Without defining a JDK, travis is using his default JDK which could OracleJDK8.